### PR TITLE
use socket.getdefaulttimeout() on App Engine as well as off, take 2

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1082,7 +1082,9 @@ try:
     def _new_fixed_fetch(validate_certificate):
         def fixed_fetch(url, payload=None, method="GET", headers={},
                         allow_truncated=False, follow_redirects=True,
-                        deadline=socket.getdefaulttimeout() or 5):
+                        deadline=None):
+            if deadline is None:
+                deadline = socket.getdefaulttimeout() or 5
             return fetch(url, payload=payload, method=method, headers=headers,
                          allow_truncated=allow_truncated,
                          follow_redirects=follow_redirects, deadline=deadline,


### PR DESCRIPTION
the first attempt (3118243f371f56ba5b6cf9d7dfcea09c98daa573) wouldn't set the timeout for clients that passed deadline=None explicitly, which App Engine's httplib often does. this fixes that.

sorry for the false start!
