### PR TITLE
Fix IndexError on Jython (#250)

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -898,7 +898,7 @@ class HTTPConnectionWithTimeout(httplib.HTTPConnection):
                     if use_proxy:
                         print "proxy: %s ************" % str((proxy_host, proxy_port, proxy_rdns, proxy_user, proxy_pass))
 
-                self.sock.connect((self.host, self.port) + sa[2:])
+                self.sock.connect((self.host, self.port) + tuple(sa)[2:])
             except socket.error, msg:
                 if self.debuglevel > 0:
                     print "connect fail: (%s, %s)" % (self.host, self.port)


### PR DESCRIPTION
Jython has an unfortunate issue where the socketaddr object isn't really a tuple, but is instead an item that acts like a tuple under some circumstances. This commit makes httplib2 convert it to an actual tuple, so that it will work as expected.

This solution isn't very nice, but without upstream fixes to Jython, this is the only obvious solution. No hard feelings if you don't want to pull this one, but it would save me some headache in our Jython environments.
