### PR TITLE
fixed not supported line endings \N by just removing them from iri2uri.py

### DIFF
--- a/python2/httplib2/iri2uri.py
+++ b/python2/httplib2/iri2uri.py
@@ -16,7 +16,7 @@ import urlparse
 
 
 # Convert an IRI to a URI following the rules in RFC 3987
-#
+# 
 # The characters we need to enocde and escape are defined in the spec:
 #
 # iprivate =  %xE000-F8FF / %xF0000-FFFFD / %x100000-10FFFD
@@ -28,28 +28,28 @@ import urlparse
 #         / %xD0000-DFFFD / %xE1000-EFFFD
 
 escape_range = [
-    (0xA0, 0xD7FF),
-    (0xE000, 0xF8FF),
-    (0xF900, 0xFDCF),
-    (0xFDF0, 0xFFEF),
-    (0x10000, 0x1FFFD),
-    (0x20000, 0x2FFFD),
-    (0x30000, 0x3FFFD),
-    (0x40000, 0x4FFFD),
-    (0x50000, 0x5FFFD),
-    (0x60000, 0x6FFFD),
-    (0x70000, 0x7FFFD),
-    (0x80000, 0x8FFFD),
-    (0x90000, 0x9FFFD),
-    (0xA0000, 0xAFFFD),
-    (0xB0000, 0xBFFFD),
-    (0xC0000, 0xCFFFD),
-    (0xD0000, 0xDFFFD),
-    (0xE1000, 0xEFFFD),
-    (0xF0000, 0xFFFFD),
-    (0x100000, 0x10FFFD),
+   (0xA0, 0xD7FF ),
+   (0xE000, 0xF8FF ),
+   (0xF900, 0xFDCF ),
+   (0xFDF0, 0xFFEF),
+   (0x10000, 0x1FFFD ),
+   (0x20000, 0x2FFFD ),
+   (0x30000, 0x3FFFD),
+   (0x40000, 0x4FFFD ),
+   (0x50000, 0x5FFFD ),
+   (0x60000, 0x6FFFD),
+   (0x70000, 0x7FFFD ),
+   (0x80000, 0x8FFFD ),
+   (0x90000, 0x9FFFD),
+   (0xA0000, 0xAFFFD ),
+   (0xB0000, 0xBFFFD ),
+   (0xC0000, 0xCFFFD),
+   (0xD0000, 0xDFFFD ),
+   (0xE1000, 0xEFFFD),
+   (0xF0000, 0xFFFFD ),
+   (0x100000, 0x10FFFD)
 ]
-
+ 
 def encode(c):
     retval = c
     i = ord(c)
@@ -63,19 +63,19 @@ def encode(c):
 
 
 def iri2uri(uri):
-    """Convert an IRI to a URI. Note that IRIs must be
+    """Convert an IRI to a URI. Note that IRIs must be 
     passed in a unicode strings. That is, do not utf-8 encode
-    the IRI before passing it into the function."""
+    the IRI before passing it into the function.""" 
     if isinstance(uri ,unicode):
         (scheme, authority, path, query, fragment) = urlparse.urlsplit(uri)
         authority = authority.encode('idna')
         # For each character in 'ucschar' or 'iprivate'
         #  1. encode as utf-8
-        #  2. then %-encode each octet of that utf-8
+        #  2. then %-encode each octet of that utf-8 
         uri = urlparse.urlunsplit((scheme, authority, path, query, fragment))
         uri = "".join([encode(c) for c in uri])
     return uri
-
+        
 if __name__ == "__main__":
     import unittest
 
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 
         def test_uris(self):
             """Test that URIs are invariant under the transformation."""
-            invariant = [
+            invariant = [ 
                 u"ftp://ftp.is.co.za/rfc/rfc1808.txt",
                 u"http://www.ietf.org/rfc/rfc2396.txt",
                 u"ldap://[2001:db8::7]/c=GB?objectClass?one",
@@ -94,17 +94,17 @@ if __name__ == "__main__":
                 u"urn:oasis:names:specification:docbook:dtd:xml:4.1.2" ]
             for uri in invariant:
                 self.assertEqual(uri, iri2uri(uri))
-
+            
         def test_iri(self):
             """ Test that the right type of escaping is done for each part of the URI."""
-            self.assertEqual("http://xn--o3h.com/%E2%98%84", iri2uri(u"http://\N{COMET}.com/\N{COMET}"))
-            self.assertEqual("http://bitworking.org/?fred=%E2%98%84", iri2uri(u"http://bitworking.org/?fred=\N{COMET}"))
-            self.assertEqual("http://bitworking.org/#%E2%98%84", iri2uri(u"http://bitworking.org/#\N{COMET}"))
-            self.assertEqual("#%E2%98%84", iri2uri(u"#\N{COMET}"))
-            self.assertEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(u"/fred?bar=\N{BLACK LEFT POINTING INDEX}#\N{COMET}"))
-            self.assertEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(iri2uri(u"/fred?bar=\N{BLACK LEFT POINTING INDEX}#\N{COMET}")))
-            self.assertNotEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(u"/fred?bar=\N{BLACK LEFT POINTING INDEX}#\N{COMET}".encode('utf-8')))
+            self.assertEqual("http://xn--o3h.com/%E2%98%84", iri2uri(u"http://{COMET}.com/{COMET}"))
+            self.assertEqual("http://bitworking.org/?fred=%E2%98%84", iri2uri(u"http://bitworking.org/?fred={COMET}"))
+            self.assertEqual("http://bitworking.org/#%E2%98%84", iri2uri(u"http://bitworking.org/#{COMET}"))
+            self.assertEqual("#%E2%98%84", iri2uri(u"#{COMET}"))
+            self.assertEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(u"/fred?bar={BLACK LEFT POINTING INDEX}#{COMET}"))
+            self.assertEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(iri2uri(u"/fred?bar={BLACK LEFT POINTING INDEX}#{COMET}")))
+            self.assertNotEqual("/fred?bar=%E2%98%9A#%E2%98%84", iri2uri(u"/fred?bar={BLACK LEFT POINTING INDEX}#{COMET}".encode('utf-8')))
 
     unittest.main()
 
-
+    


### PR DESCRIPTION
this was necessary to build httplib2 with kivy/buildozer for android using the kivy-virtualbox image (ubuntu 12.10)

there are more changes shown in the diff below..
most them shouldn't make any difference,

the important changes are:
removed any \N within lines 100-106

was not sure about line 50, so I looked it up, and looks like python allows a comma after last list element to reduce diffs after changing multi-line lists.. so this should be okay to keep ;-)
