### PR TITLE
Basic travis-ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - '2.7'
+  - '3.4'
+  - '2.6'
+  - '3.3'
+  - '3.2'
+
+install:
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then
+      wget https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.15.zip;
+      unzip -q google_appengine_1.9.15.zip;
+    fi
+
+script:
+  - cd python${TRAVIS_PYTHON_VERSION:0:1}
+  - python httplib2test.py
+  - if [[ "${TRAVIS_PYTHON_VERSION:0:1}" == "2" ]]; then
+      PYTHONPATH="$PYTHONPATH:../google_appengine" python httplib2test_appengine.py;
+    fi


### PR DESCRIPTION
https://travis-ci.org/jayvdb/httplib2/builds/42097318

Some tests are failing because of a problem with the test server
http://bitworking.org/projects/httplib2/test/303/303.cgi

We can remove dependency on the bitworking server for the asis test files by using https://pypi.python.org/pypi/asis

Most of the dynamic cgi tests could be rewritten as asis test files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jcgregorio/httplib2/290)
<!-- Reviewable:end -->
