### PR TITLE
Fix compatibility issue with Jython 2.7

### DIFF
--- a/python2/httplib2/socks.py
+++ b/python2/httplib2/socks.py
@@ -113,7 +113,7 @@ def wrapmodule(module):
     else:
         raise GeneralProxyError((4, "no proxy specified"))
 
-class socksocket(socket.socket):
+class socksocket(socket.socket().__class__):
     """socksocket([family[, type[, proto]]]) -> socket object
     Open a SOCKS enabled socket. The parameters are the same as
     those of the standard socket init. In order for SOCKS to work,


### PR DESCRIPTION
When loading httplib2 in Jython 2.7 you get an error:

```
>>> import httplib2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "testenv/lib/python2.7/site-packages/httplib2/__init__.py", line 59, in <module>
    from httplib2 import socks
  File "testenv/lib/python2.7/site-packages/httplib2/__init__.py", line 59, in <module>
    from httplib2 import socks
  File "testenv/lib/python2.7/site-packages/httplib2/socks.py", line 116, in <module>
    class socksocket(socket.socket):
TypeError: Error when calling the metaclass bases
    function() argument 1 must be code, not str
```

In Jython 2.7b3 and later, `socket.socket` is defined as a function like this:

```
def socket(family=None, type=None, proto=None):
    return _socketobject(family, type, proto)

...

class _socketobject(object):
...
```

Thus it seems the only way to extend this class without knowing about Jython library internals is to instantiate and get the class at runtime.

I don't know if this is the best solution, but this patch works for me with Jython 2.7rc2 and Python 2.7.9, tested with the Google Drive API.
