### PR TITLE
Fix handling of RETRIES parameter

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1291,14 +1291,14 @@ class Http(object):
                 # Just because the server closed the connection doesn't apparently mean
                 # that the server didn't send a response.
                 if hasattr(conn, 'sock') and conn.sock is None:
-                    if i < RETRIES-1:
+                    if i < RETRIES:
                         conn.close()
                         conn.connect()
                         continue
                     else:
                         conn.close()
                         raise
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue
@@ -1318,7 +1318,7 @@ class Http(object):
                     conn.close()
                     raise
             except (socket.error, httplib.HTTPException):
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -998,14 +998,14 @@ class Http(object):
                     raise
             except http.client.HTTPException:
                 if conn.sock is None:
-                    if i < RETRIES-1:
+                    if i < RETRIES:
                         conn.close()
                         conn.connect()
                         continue
                     else:
                         conn.close()
                         raise
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue
@@ -1031,7 +1031,7 @@ class Http(object):
                 raise
             except (socket.error, http.client.HTTPException):
                 conn.close()
-                if i == 0:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue


### PR DESCRIPTION
Currently, the library tries to execute a request at most `RETRIES-1` times.
With the default value of `RETRIES=2`, you can get errors when making a new request after the server or OS has closed the socket.

With this fix, the request will be tried up to `RETRIES` times.