### PR TITLE
Fix incorrect ResponseNotReady exceptions, retry on transient errors.

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1285,8 +1285,9 @@ class Http(object):
                     err = getattr(e, 'args')[0]
                 else:
                     err = e.errno
-                if err == errno.ECONNREFUSED: # Connection refused
-                    raise
+                if err in (errno.ENETUNREACH, errno.EADDRNOTAVAIL) and i < RETRIES:
+                    continue  # retry on potentially transient socket errors
+                raise
             except httplib.HTTPException:
                 # Just because the server closed the connection doesn't apparently mean
                 # that the server didn't send a response.

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -994,8 +994,9 @@ class Http(object):
                 raise ServerNotFoundError("Unable to find the server at %s" % conn.host)
             except socket.error as e:
                 errno_ = (e.args[0].errno if isinstance(e.args[0], socket.error) else e.errno)
-                if errno_ == errno.ECONNREFUSED: # Connection refused
-                    raise
+                if errno_ in (errno.ENETUNREACH, errno.EADDRNOTAVAIL) and i < RETRIES:
+                    continue  # retry on potentially transient errors
+                raise
             except http.client.HTTPException:
                 if conn.sock is None:
                     if i < RETRIES-1:


### PR DESCRIPTION
For socket errors besides Connection Refused, the code will swallow the
error and fall through to a misleading "ResponseNotReady" exception. This
is both incorrect and unhelpful. The code also does not retry on errors that
are potentially transient, ie, Network Unreachable or Address Not Available.

This patch addresses both concerns by raising the socket error so
that application code can handle it appropriately, or retrying if
the socket error is transient.

This likely resolves Issue #284 .