### PR TITLE
Jython compatibility issue

### DIFF
--- a/python2/httplib2/socks.py
+++ b/python2/httplib2/socks.py
@@ -41,7 +41,7 @@ mainly to merge bug fixes found in Sourceforge
 """
 
 import base64
-import socket
+from socket import socket
 import struct
 import sys
 


### PR DESCRIPTION
Relating to issue jcgregorio/httplib2#300
0.9.2 release didn't fix Jython compatibility issue

Proposing fix : ```from socket import socket``` instead of import socket