### PR TITLE
Fix retries comparisons

### DIFF
--- a/python2/httplib2/__init__.py
+++ b/python2/httplib2/__init__.py
@@ -1293,14 +1293,14 @@ class Http(object):
                 # Just because the server closed the connection doesn't apparently mean
                 # that the server didn't send a response.
                 if hasattr(conn, 'sock') and conn.sock is None:
-                    if i < RETRIES-1:
+                    if i < RETRIES:
                         conn.close()
                         conn.connect()
                         continue
                     else:
                         conn.close()
                         raise
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue
@@ -1320,7 +1320,7 @@ class Http(object):
                     conn.close()
                     raise
             except (socket.error, httplib.HTTPException):
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue

--- a/python3/httplib2/__init__.py
+++ b/python3/httplib2/__init__.py
@@ -999,14 +999,14 @@ class Http(object):
                 raise
             except http.client.HTTPException:
                 if conn.sock is None:
-                    if i < RETRIES-1:
+                    if i < RETRIES:
                         conn.close()
                         conn.connect()
                         continue
                     else:
                         conn.close()
                         raise
-                if i < RETRIES-1:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue
@@ -1032,7 +1032,7 @@ class Http(object):
                 raise
             except (socket.error, http.client.HTTPException):
                 conn.close()
-                if i == 0:
+                if i < RETRIES:
                     conn.close()
                     conn.connect()
                     continue


### PR DESCRIPTION
i goes on the loop from 1 ... RETRIES, so the right comparison to do is i < RETRIES.

The third change, the i == 0 can never happen, i starts at 1. Anyway the right comparison is i < RETRIES, because i == 1 will cause a continue even when RETRIES is 1, and that will exit the loop without a proper response/content variables, raising an error on the return.
