### PR TITLE
Fix tiny typo, and -> an

### DIFF
--- a/doc/libhttplib2.rst
+++ b/doc/libhttplib2.rst
@@ -261,7 +261,7 @@ Http Objects
    The *connection_type* is the type of connection object to use. The supplied
    class should implement the interface of httplib.HTTPConnection.
 
-   The return value is a tuple of (response, content), the first being and instance
+   The return value is a tuple of (response, content), the first being an instance
    of the :class:`Response` class, the second being a string that contains the
    response entity body.
 


### PR DESCRIPTION
Fixes a tiny typo in Http.request docs, and -> an.